### PR TITLE
Add warning message to prevent breaking loot chests on player join

### DIFF
--- a/src/main/kotlin/event/player/PlayerJoin.kt
+++ b/src/main/kotlin/event/player/PlayerJoin.kt
@@ -35,6 +35,7 @@ class PlayerJoin : Listener {
             .build()
 
         e.player.sendResourcePacks(resourcePackRequest)
+        e.player.sendMessage(mm.deserialize("<red>⚠ <reset>Please <b>do not</b> break loot chests!"))
         e.joinMessage(Formatting.allTags.deserialize("<tbdcolour>${e.player.name}<reset> joined the game."))
     }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/657d6dcc-711c-4c7f-9d16-04d4406edcd3)
