### PR TITLE
Allow players to lock item frames

### DIFF
--- a/src/main/kotlin/event/player/ItemFrameInteract.kt
+++ b/src/main/kotlin/event/player/ItemFrameInteract.kt
@@ -29,6 +29,7 @@ object ItemFrameInteract {
                 val location = itemFrame.location.toBlockLocation().add(0.5, 0.5, 0.5)
                 itemFrame.location.world.spawnParticle(Particle.WAX_ON, location, 10, 0.5, 0.5, 0.5)
                 player.inventory.itemInMainHand.amount = amount - 1
+                event.isCancelled = true
             }
 
             Material.WOODEN_AXE, Material.STONE_AXE, Material.IRON_AXE, Material.GOLDEN_AXE, Material.DIAMOND_AXE, Material.NETHERITE_AXE -> {
@@ -44,7 +45,6 @@ object ItemFrameInteract {
                 itemMeta.damage = newDamage
                 player.inventory.itemInMainHand.itemMeta = itemMeta
                 // Break axe if it reaches max damage
-                player.sendMessage(itemMeta.toString())
                 if(itemMeta.damage.toShort() == player.inventory.itemInMainHand.type.maxDurability) {
                     player.inventory.setItemInMainHand(ItemStack(Material.AIR))
                 }

--- a/src/main/kotlin/event/player/ItemFrameInteract.kt
+++ b/src/main/kotlin/event/player/ItemFrameInteract.kt
@@ -1,16 +1,59 @@
 package event.player
 
 import org.bukkit.Material
+import org.bukkit.Particle
 import org.bukkit.entity.ItemFrame
 import org.bukkit.event.player.PlayerInteractEntityEvent
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.meta.Damageable
 
 object ItemFrameInteract {
-    fun itemframeInteractEvent(event: PlayerInteractEntityEvent) {
+    fun itemFrameInteractEvent(event: PlayerInteractEntityEvent) {
         val itemFrame = event.rightClicked as? ItemFrame ?: return
-        if (event.player.isSneaking && event.player.inventory.itemInMainHand.type === Material.AIR) {
-            val newVisibility = !itemFrame.isVisible()
-            itemFrame.setVisible(newVisibility)
-            event.setCancelled(true)
+        val player = event.player
+        if (!player.isSneaking) return
+        when (player.inventory.itemInMainHand.type) {
+            Material.AIR -> {
+                val newVisibility = !itemFrame.isVisible
+                itemFrame.isVisible = newVisibility
+                event.isCancelled = true
+            }
+
+            Material.HONEYCOMB -> {
+                if (itemFrame.isFixed) {
+                    // Do nothing if item frame is already fixed
+                    return
+                }
+                itemFrame.isFixed = true
+                val amount = player.inventory.itemInMainHand.amount
+                val location = itemFrame.location.toBlockLocation().add(0.5, 0.5, 0.5)
+                itemFrame.location.world.spawnParticle(Particle.WAX_ON, location, 10, 0.5, 0.5, 0.5)
+                player.inventory.itemInMainHand.amount = amount - 1
+            }
+
+            Material.WOODEN_AXE, Material.STONE_AXE, Material.IRON_AXE, Material.GOLDEN_AXE, Material.DIAMOND_AXE, Material.NETHERITE_AXE -> {
+                if(!itemFrame.isFixed) {
+                    // Do nothing if item frame is not fixed
+                    return
+                }
+                itemFrame.isFixed = false
+                val location = itemFrame.location.toBlockLocation().add(0.5, 0.5, 0.5)
+                itemFrame.location.world.spawnParticle(Particle.WAX_OFF, location, 10, 0.5, 0.5, 0.5)
+                val itemMeta = player.inventory.itemInMainHand.itemMeta as Damageable
+                val newDamage = itemMeta.damage + 1
+                itemMeta.damage = newDamage
+                player.inventory.itemInMainHand.itemMeta = itemMeta
+                // Break axe if it reaches max damage
+                player.sendMessage(itemMeta.toString())
+                if(itemMeta.damage.toShort() == player.inventory.itemInMainHand.type.maxDurability) {
+                    player.inventory.setItemInMainHand(ItemStack(Material.AIR))
+                }
+                event.isCancelled = true
+            }
+
+            else -> {
+                // Ignore other interactions for now
+            }
         }
     }
 }

--- a/src/main/kotlin/event/player/PlayerInteractEntity.kt
+++ b/src/main/kotlin/event/player/PlayerInteractEntity.kt
@@ -1,6 +1,6 @@
 package event.player
 
-import event.player.ItemFrameInteract.itemframeInteractEvent
+import event.player.ItemFrameInteract.itemFrameInteractEvent
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerInteractEntityEvent
@@ -9,7 +9,7 @@ class PlayerInteractEntity : Listener{
     @EventHandler
     fun onPlayerInteract(event: PlayerInteractEntityEvent) {
         if (event.hand.equals(org.bukkit.inventory.EquipmentSlot.HAND)) { // The reason for this is really funny
-            itemframeInteractEvent(event)
+            itemFrameInteractEvent(event)
         }
     }
 }


### PR DESCRIPTION
Allows players to wax an item frame by shift right clicking an item frame with honeycomb (like copper & signs). This can be removed by shift right clicking with any axe. 

It has the following effect:
- This disables rotation and adding/removing the item
- Can also not destroy the Item Frame unless unwaxed